### PR TITLE
Factor reference tests for the proposal to avoid confusion

### DIFF
--- a/test/core/globals.wast
+++ b/test/core/globals.wast
@@ -51,9 +51,25 @@
   "global is immutable"
 )
 
-;; mutable globals can be exported
-(module (global (mut f32) (f32.const 0)) (export "a" (global 0)))
-(module (global (export "a") (mut f32) (f32.const 0)))
+;;(assert_invalid
+;;  (module (import "m" "a" (global (mut i32))))
+;;  "mutable globals cannot be imported"
+;;)
+;;
+;;(assert_invalid
+;;  (module (global (import "m" "a") (mut i32)))
+;;  "mutable globals cannot be imported"
+;;)
+;;
+;;(assert_invalid
+;;  (module (global (mut f32) (f32.const 0)) (export "a" (global 0)))
+;;  "mutable globals cannot be exported"
+;;)
+;;
+;;(assert_invalid
+;;  (module (global (export "a") (mut f32) (f32.const 0)))
+;;  "mutable globals cannot be exported"
+;;)
 
 (assert_invalid
   (module (global f32 (f32.neg (f32.const 0))))

--- a/test/core/globals_proposed.wast
+++ b/test/core/globals_proposed.wast
@@ -1,0 +1,5 @@
+;; Test exportable mutable globals
+
+;; mutable globals can be exported
+(module (global (mut f32) (f32.const 0)) (export "a" (global 0)))
+(module (global (export "a") (mut f32) (f32.const 0)))

--- a/test/core/linking.wast
+++ b/test/core/linking.wast
@@ -39,29 +39,16 @@
 (module $Mg
   (global $glob (export "glob") i32 (i32.const 42))
   (func (export "get") (result i32) (get_global $glob))
-
-  ;; export mutable globals
-  (global $mut_glob (export "mut_glob") (mut i32) (i32.const 142))
-  (func (export "get_mut") (result i32) (get_global $mut_glob))
-  (func (export "set_mut") (param i32) (set_global $mut_glob (get_local 0)))
 )
 (register "Mg" $Mg)
 
 (module $Ng
   (global $x (import "Mg" "glob") i32)
-  (global $mut_glob (import "Mg" "mut_glob") (mut i32))
   (func $f (import "Mg" "get") (result i32))
-  (func $get_mut (import "Mg" "get_mut") (result i32))
-  (func $set_mut (import "Mg" "set_mut") (param i32))
-
   (export "Mg.glob" (global $x))
   (export "Mg.get" (func $f))
   (global $glob (export "glob") i32 (i32.const 43))
   (func (export "get") (result i32) (get_global $glob))
-
-  (export "Mg.mut_glob" (global $mut_glob))
-  (export "Mg.get_mut" (func $get_mut))
-  (export "Mg.set_mut" (func $set_mut))
 )
 
 (assert_return (get $Mg "glob") (i32.const 42))
@@ -71,26 +58,6 @@
 (assert_return (invoke $Ng "Mg.get") (i32.const 42))
 (assert_return (invoke $Ng "get") (i32.const 43))
 
-(assert_return (get $Mg "mut_glob") (i32.const 142))
-(assert_return (get $Ng "Mg.mut_glob") (i32.const 142))
-(assert_return (invoke $Mg "get_mut") (i32.const 142))
-(assert_return (invoke $Ng "Mg.get_mut") (i32.const 142))
-
-(assert_return (invoke $Mg "set_mut" (i32.const 241)))
-(assert_return (get $Mg "mut_glob") (i32.const 241))
-(assert_return (get $Ng "Mg.mut_glob") (i32.const 241))
-(assert_return (invoke $Mg "get_mut") (i32.const 241))
-(assert_return (invoke $Ng "Mg.get_mut") (i32.const 241))
-
-
-(assert_unlinkable
-  (module (import "Mg" "mut_glob" (global i32)))
-  "incompatible import type"
-)
-(assert_unlinkable
-  (module (import "Mg" "glob" (global (mut i32))))
-  "incompatible import type"
-)
 
 ;; Tables
 

--- a/test/core/linking_proposed.wast
+++ b/test/core/linking_proposed.wast
@@ -1,0 +1,48 @@
+(module $Mg
+  (global $glob (export "glob") i32 (i32.const 42))
+  (func (export "get") (result i32) (get_global $glob))
+
+  ;; export mutable globals
+  (global $mut_glob (export "mut_glob") (mut i32) (i32.const 142))
+  (func (export "get_mut") (result i32) (get_global $mut_glob))
+  (func (export "set_mut") (param i32) (set_global $mut_glob (get_local 0)))
+)
+(register "Mg" $Mg)
+
+(module $Ng
+  (global $x (import "Mg" "glob") i32)
+  (global $mut_glob (import "Mg" "mut_glob") (mut i32))
+  (func $f (import "Mg" "get") (result i32))
+  (func $get_mut (import "Mg" "get_mut") (result i32))
+  (func $set_mut (import "Mg" "set_mut") (param i32))
+
+  (export "Mg.glob" (global $x))
+  (export "Mg.get" (func $f))
+  (global $glob (export "glob") i32 (i32.const 43))
+  (func (export "get") (result i32) (get_global $glob))
+
+  (export "Mg.mut_glob" (global $mut_glob))
+  (export "Mg.get_mut" (func $get_mut))
+  (export "Mg.set_mut" (func $set_mut))
+)
+
+(assert_return (get $Mg "mut_glob") (i32.const 142))
+(assert_return (get $Ng "Mg.mut_glob") (i32.const 142))
+(assert_return (invoke $Mg "get_mut") (i32.const 142))
+(assert_return (invoke $Ng "Mg.get_mut") (i32.const 142))
+
+(assert_return (invoke $Mg "set_mut" (i32.const 241)))
+(assert_return (get $Mg "mut_glob") (i32.const 241))
+(assert_return (get $Ng "Mg.mut_glob") (i32.const 241))
+(assert_return (invoke $Mg "get_mut") (i32.const 241))
+(assert_return (invoke $Ng "Mg.get_mut") (i32.const 241))
+
+
+(assert_unlinkable
+  (module (import "Mg" "mut_glob" (global i32)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "Mg" "glob" (global (mut i32))))
+  "incompatible import type"
+)


### PR DESCRIPTION
As discussed in the context of the proposal for the sign extension ops, we should keep tests introduced by a proposal in separate files until the proposal is stable, so that it is easier for implementations to handle the new tests without having to deal with any other changes to the test file where the tests eventually belong.

This patch factors the tests for the exportable/importable mutable globals into separate files, core/globals_proposed.wast and core/linking_proposed. wast.  Eventually these should be merged into globals.wast and linking.wast, or renamed in some way to remove the "_proposed" suffix.

The present proposal has a unique challenge in that it actually invalidates existing semantics in a corner case, so some existing tests have to be removed (from globals.wast).  I have opted here to comment them out, as documentation, so that they can be removed eventually when the proposal has been approved.