### PR TITLE
Unwrap WebAssembly.Global objects in generated JS

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -61,7 +61,8 @@ let harness =
   "}\n" ^
   "\n" ^
   "function get(instance, name) {\n" ^
-  "  return instance.exports[name];\n" ^
+  "  let v = instance.exports[name];\n" ^
+  "  return (v instanceof WebAssembly.Global) ? v.value : v;\n" ^
   "}\n" ^
   "\n" ^
   "function exports(name, instance) {\n" ^


### PR DESCRIPTION
The `get` accessor will now unwrap an exported `WebAssembly.Global`
value into its underlying primitive value. This way `Object.is` can
still be used for the assertions.

See issue #10.