### PR TITLE
Change global descriptor field: "type" -> "value"

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -787,8 +787,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. Let |global| be the {{Global}} instance.
     1. Let |store| be the current agent's [=associated store=].
     1. Let |globaladdr| be |global|.\[[Global]].
-    1. Let |globaltype| be [=type_global=](|store|, |globaladdr|).
-    1. Assert: |globaltype| is of the form |mut| |valuetype|.
+    1. Let |globaltype| be [=type_global=](|store|, |globaladdr|), where |globaltype| is of the form |mut| |valuetype|.
     1. If |mut| is [=const=], throw a {{TypeError}.
     1. If |valuetype| is [=𝗂𝟨𝟦=], throw a {{TypeError}}.
     1. Let |value| be [=ToWebAssemblyValue=](|v|, |valuetype|).

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -719,7 +719,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
 
 <pre class="idl">
 dictionary GlobalDescriptor {
-  required USVString type;
+  required USVString value;
   boolean mutable = false;
 };
 
@@ -759,9 +759,9 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
 <div algorithm>
     The <dfn constructor for="Global">Global(descriptor, v)</dfn> constructor, when invoked, performs the following steps:
     1. Let |mutable| be |descriptor|["mutable"].
-    1. Let |type| be [=ToValueType=](|descriptor|["type"]).
-    1. Let |value| be [=ToWebAssemblyValue=](|v|, |type|).
-    1. If |mutable| is true, let |globaltype| be [=var=] |type|; otherwise, let |globaltype| be [=const=] |type|.
+    1. Let |valuetype| be [=ToValueType=](|descriptor|["value"]).
+    1. Let |value| be [=ToWebAssemblyValue=](|v|, |valuetype|).
+    1. If |mutable| is true, let |globaltype| be [=var=] |valuetype|; otherwise, let |globaltype| be [=const=] |valuetype|.
     1. Let |store| be the current agent's [=associated store=].
     1. Let (|store|, |globaladdr|) be [=alloc_global=](|store|, |globaltype|, |value|). <!-- TODO(littledan): Report allocation failure https://github.com/WebAssembly/spec/issues/584 -->
     1. Set the current agent's [=associated store=] to |store|.
@@ -773,7 +773,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. Let |store| be the current agent's [=associated store=].
     1. Let |globaladdr| be |global|.\[[Global]].
     1. Let |globaltype| be [=type_global=](|store|, |globaladdr|).
-    1. If |type| is [=𝗂𝟨𝟦=], throw a {{TypeError}}.
+    1. If |globaltype| is of the form |mut| [=𝗂𝟨𝟦=], throw a {{TypeError}}.
     1. Let |value| be [=read_global=](|store|, |globaladdr|).
     1. Return [=ToJSValue=](|value|).
 </div>
@@ -788,9 +788,10 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. Let |store| be the current agent's [=associated store=].
     1. Let |globaladdr| be |global|.\[[Global]].
     1. Let |globaltype| be [=type_global=](|store|, |globaladdr|).
-    1. If |globaltype| is of the form [=const=] |type|, throw a {{TypeError}.
-    1. If |type| is [=𝗂𝟨𝟦=], throw a {{TypeError}}.
-    1. Let |value| be [=ToWebAssemblyValue=](|v|, |type|).
+    1. Assert: |globaltype| is of the form |mut| |valuetype|.
+    1. If |mut| is [=const=], throw a {{TypeError}.
+    1. If |valuetype| is [=𝗂𝟨𝟦=], throw a {{TypeError}}.
+    1. Let |value| be [=ToWebAssemblyValue=](|v|, |valuetype|).
     1. Let |store| be [=write_global=](|store|, |globaladdr|, |value|).
     1. If |store| is [=error=], throw a {{RangeError}} exception.
     1. Set the current agent's [=associated store=] to |store|.

--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -688,26 +688,26 @@ test(() => {
     assertThrows(() => Global(), TypeError);
     assertThrows(() => new Global(1), TypeError);
     assertThrows(() => new Global({}), TypeError);
-    assertThrows(() => new Global({type: 'foo'}), TypeError);
-    assertThrows(() => new Global({type: 'i64'}), TypeError);
-    assert_equals(new Global({type:'i32'}) instanceof Global, true);
-    assert_equals(new Global({type:'f32'}) instanceof Global, true);
-    assert_equals(new Global({type:'f64'}) instanceof Global, true);
-    assert_equals(new Global({type:'i32', mutable: false}) instanceof Global, true);
-    assert_equals(new Global({type:'f64', mutable: false}) instanceof Global, true);
-    assert_equals(new Global({type:'f64', mutable: false}) instanceof Global, true);
-    assert_equals(new Global({type:'i32', mutable: true}) instanceof Global, true);
-    assert_equals(new Global({type:'f64', mutable: true}) instanceof Global, true);
-    assert_equals(new Global({type:'f64', mutable: true}) instanceof Global, true);
-    assert_equals(new Global({type:'i32'}, 0x132) instanceof Global, true);
-    assert_equals(new Global({type:'f32'}, 0xf32) instanceof Global, true);
-    assert_equals(new Global({type:'f64'}, 0xf64) instanceof Global, true);
-    assert_equals(new Global({type:'i32', mutable: false}, 0x132) instanceof Global, true);
-    assert_equals(new Global({type:'f32', mutable: false}, 0xf32) instanceof Global, true);
-    assert_equals(new Global({type:'f64', mutable: false}, 0xf64) instanceof Global, true);
-    assert_equals(new Global({type:'i32', mutable: true}, 0x132) instanceof Global, true);
-    assert_equals(new Global({type:'f32', mutable: true}, 0xf32) instanceof Global, true);
-    assert_equals(new Global({type:'f64', mutable: true}, 0xf64) instanceof Global, true);
+    assertThrows(() => new Global({value: 'foo'}), TypeError);
+    assertThrows(() => new Global({value: 'i64'}), TypeError);
+    assert_equals(new Global({value:'i32'}) instanceof Global, true);
+    assert_equals(new Global({value:'f32'}) instanceof Global, true);
+    assert_equals(new Global({value:'f64'}) instanceof Global, true);
+    assert_equals(new Global({value:'i32', mutable: false}) instanceof Global, true);
+    assert_equals(new Global({value:'f64', mutable: false}) instanceof Global, true);
+    assert_equals(new Global({value:'f64', mutable: false}) instanceof Global, true);
+    assert_equals(new Global({value:'i32', mutable: true}) instanceof Global, true);
+    assert_equals(new Global({value:'f64', mutable: true}) instanceof Global, true);
+    assert_equals(new Global({value:'f64', mutable: true}) instanceof Global, true);
+    assert_equals(new Global({value:'i32'}, 0x132) instanceof Global, true);
+    assert_equals(new Global({value:'f32'}, 0xf32) instanceof Global, true);
+    assert_equals(new Global({value:'f64'}, 0xf64) instanceof Global, true);
+    assert_equals(new Global({value:'i32', mutable: false}, 0x132) instanceof Global, true);
+    assert_equals(new Global({value:'f32', mutable: false}, 0xf32) instanceof Global, true);
+    assert_equals(new Global({value:'f64', mutable: false}, 0xf64) instanceof Global, true);
+    assert_equals(new Global({value:'i32', mutable: true}, 0x132) instanceof Global, true);
+    assert_equals(new Global({value:'f32', mutable: true}, 0xf32) instanceof Global, true);
+    assert_equals(new Global({value:'f64', mutable: true}, 0xf64) instanceof Global, true);
 }, "'WebAssembly.Global' constructor function");
 
 test(() => {
@@ -727,12 +727,12 @@ test(() => {
 }, "'WebAssembly.Global.prototype' object");
 
 test(() => {
-    globalI32 = new Global({type: 'i32'}, 0x132);
-    globalF32 = new Global({type: 'f32'}, 0xf32);
-    globalF64 = new Global({type: 'f64'}, 0xf64);
-    globalI32Mut = new Global({type: 'i32', mutable: true}, 0x132);
-    globalF32Mut = new Global({type: 'f32', mutable: true}, 0xf32);
-    globalF64Mut = new Global({type: 'f64', mutable: true}, 0xf64);
+    globalI32 = new Global({value: 'i32'}, 0x132);
+    globalF32 = new Global({value: 'f32'}, 0xf32);
+    globalF64 = new Global({value: 'f64'}, 0xf64);
+    globalI32Mut = new Global({value: 'i32', mutable: true}, 0x132);
+    globalF32Mut = new Global({value: 'f32', mutable: true}, 0xf32);
+    globalF64Mut = new Global({value: 'f64', mutable: true}, 0xf64);
     assert_equals(typeof globalI32, "object");
     assert_equals(String(globalI32), "[object WebAssembly.Global]");
     assert_equals(Object.getPrototypeOf(globalI32), globalProto);
@@ -853,9 +853,9 @@ test(() => {
 }, "'WebAssembly.Global.prototype.valueOf' method");
 
 test(() => {
-    assert_equals(new Global({type: 'i32'}).value, 0);
-    assert_equals(new Global({type: 'f32'}).value, 0);
-    assert_equals(new Global({type: 'f64'}).value, 0);
+    assert_equals(new Global({value: 'i32'}).value, 0);
+    assert_equals(new Global({value: 'f32'}).value, 0);
+    assert_equals(new Global({value: 'f64'}).value, 0);
 }, "'WebAssembly.Global' default value is 0");
 
 test(() => {


### PR DESCRIPTION
We decided in the May 15th CG meeting to use the name "value" instead of
"type".

I also renamed `|type|` to `|valuetype|` in the JS API spec, and fixed
some destructuring issues there too. I also updated the tests.